### PR TITLE
Elee/user name angled border fix

### DIFF
--- a/Chatbox_css.css
+++ b/Chatbox_css.css
@@ -83,7 +83,7 @@ body {
     opacity: 0;
 }
  
-#log .message,#log .meta {
+#log .message,#log .meta, #log .nameBorder {
     vertical-align: top;
     display: table-cell;
     padding-bottom: 0.1em;
@@ -96,16 +96,20 @@ body {
   text-transform: uppercase;
 }
 
-/* Username box */
+/* Username Box */
 #log .meta {
-  background-color: var(--white);
+  background-color: var(--cyan);
   z-index: 1;
   width: fit-content;
   margin-left: -2px;
-  margin-right: -20px;
   /* This clips the bottom right corner of the user box*/
   -webkit-clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
   clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
+  
+  /* This adds a border to the top, left, and bottom side of the box*/
+  border-style:solid;
+  border-color:white;
+  border-width: 2px;
 }
 
 /* Message text*/
@@ -130,6 +134,7 @@ body {
 
 /* border around message bubble */
 #log .message {
+  z-index: -3;
   border-color: var(--cyan);
   border-style: solid;
   border-width: 0px
@@ -146,28 +151,24 @@ body {
 }
 
 .name {
-    margin-left: 0.0em;
+  margin-left: 0.0em;
   margin-right: 0.0em;
 }
 
-.outerNameBorder {
-  position: absolute;
-  z-index: -5;
-  margin-top: 2px;
-  margin-left: 15px;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 36px;
-  width: 90%;
-  background: var(--cyan);
-  -webkit-clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
-  clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
+#log .meta:after {
+  content: "";
+  position:absolute;
+  width:40px;
+  height:40px;
+  overflow:hidden;
+  background-color:white;
+  transform:rotate(-45deg) translateX(15%) translateY(45%);
 }
 
-.innerMessageBorder {
+.messageBorder {
+  z-index: -4;
   position: absolute;
-  margin-top: 20px;
+  margin-top: 24px;
   margin-left: 13px;
   margin-right: 13.5px;
   margin-bottom: 8.5px;
@@ -175,9 +176,7 @@ body {
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: cyan;
+  background: var(--cyan);
   -webkit-clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
   clip-path: polygon(100% 0, 100% 80%, 95% 100%, 0 100%, 0 0);
 }
-
-span + span { margin-top: 10px; }

--- a/Chatbox_html.html
+++ b/Chatbox_html.html
@@ -8,15 +8,16 @@
     <span class="meta" style="color: black">
       <span class="badges">
       </span>
-        <span class="outerNameBorder"> </span>
       <span class="name">
       {from}
+      </span>
+         
       <span class="colon">
       :
   </span>
   </span>
-  </span>
-  <span class="innerMessageBorder"> </span>
+ 
+  <span class="messageBorder"> </span>
     <span class="message">{message} </span>
   </div>
   <p></p>


### PR DESCRIPTION
Removed the inner border method for the name. Was causing issues with either Z position or not scaling to the content of the names and badges. Opted for using pseudo-element with :after to create white box that only appears in the bottom right corner.